### PR TITLE
add new codespaces url to cors domains

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -10,7 +10,8 @@
 domains = [
   'dbh-ite.com',
   'github.dev',
-  'githubpreview.dev'
+  'githubpreview.dev',
+  'preview.app.github.dev'
 ].join('|')
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do


### PR DESCRIPTION
this allows front end devs using Codespaces to hit the api without cors errors